### PR TITLE
Private cloud support

### DIFF
--- a/source/app/components/footer.tsx
+++ b/source/app/components/footer.tsx
@@ -42,7 +42,7 @@ class FooterBase extends React.PureComponent<Props> {
     private resetTitleId = (): void => {
         PlayFab.settings.titleId = null;
         this.props.dispatch(actionSetTitleId(null));
-        this.props.history.push(routes.Index());
+        this.props.history.push(routes.Index(""));
     }
 }
 

--- a/source/app/pages/index.tsx
+++ b/source/app/pages/index.tsx
@@ -25,10 +25,10 @@ class IndexPageBase extends React.Component<Props, IState> {
     constructor(props: Props) {
         super(props);
 
-        const cloudParam = (props.match.params as any).cloud || "";
+        const cloudParam = (props.match.params as any).cloud || null;
 
         this.state = {
-            titleId: "",
+            titleId: null,
             cloud: cloudParam,
         }
     }

--- a/source/app/pages/index.tsx
+++ b/source/app/pages/index.tsx
@@ -9,6 +9,7 @@ import styled, { DivConfirm, DivField } from "../styles";
 import { IWithAppStateProps, withAppState } from "../containers/with-app-state";
 import { Grid } from "../components/grid";
 import { is } from "../shared/is";
+import { utilities } from "../shared/utilities";
 
 const TextFieldTitleId = styled(TextField)`
     max-width: 20em;
@@ -89,9 +90,10 @@ class IndexPageBase extends React.Component<Props, IState> {
 
         PlayFab.settings.titleId = this.state.titleId;
         
-        if(this.state.cloud.length > 0)
+        if(!is.null(this.state.cloud))
         {
-            (PlayFab as any)._internalSettings.productionServerUrl = `.${this.state.cloud}.playfabapi.com`
+            utilities.setPrivateCloud(this.state.cloud);
+            (PlayFab as any)._internalSettings.productionServerUrl = `.${this.state.cloud}.playfabapi.com`;
         }
         
         this.props.history.push(routes.MainMenu(this.state.titleId));

--- a/source/app/pages/index.tsx
+++ b/source/app/pages/index.tsx
@@ -25,11 +25,11 @@ class IndexPageBase extends React.Component<Props, IState> {
     constructor(props: Props) {
         super(props);
 
-        const cloud = (props.match.params as any).cloud || "";
+        const cloudParam = (props.match.params as any).cloud || "";
 
         this.state = {
             titleId: "",
-            cloud,
+            cloud: cloudParam,
         }
     }
 
@@ -84,8 +84,15 @@ class IndexPageBase extends React.Component<Props, IState> {
 <<<<<<< HEAD
 =======
     private saveTitleID = (): void => {
+<<<<<<< HEAD
         (PlayFab as any)._internalSettings.productionServerUrl = `.spi.playfabapi.com`
 >>>>>>> Works hardcoded cloud
+=======
+        if(this.state.cloud.length > 0)
+        {
+            (PlayFab as any)._internalSettings.productionServerUrl = `.${this.state.cloud}.playfabapi.com`
+        }
+>>>>>>> Add private cloud support
         PlayFab.settings.titleId = this.state.titleId;
         
         this.props.history.push(routes.MainMenu(this.state.titleId));

--- a/source/app/pages/index.tsx
+++ b/source/app/pages/index.tsx
@@ -76,24 +76,23 @@ class IndexPageBase extends React.Component<Props, IState> {
         });
     }
 
+    private onChangeCloud = (_: any, cloud: string): void => {
+        this.setState({
+            cloud: cloud.trim(),
+        });
+    }
+
     private continue = (e: React.SyntheticEvent<any>): void => {
         if(!is.null(e)) {
             e.preventDefault();
         }
 
-<<<<<<< HEAD
-=======
-    private saveTitleID = (): void => {
-<<<<<<< HEAD
-        (PlayFab as any)._internalSettings.productionServerUrl = `.spi.playfabapi.com`
->>>>>>> Works hardcoded cloud
-=======
+        PlayFab.settings.titleId = this.state.titleId;
+        
         if(this.state.cloud.length > 0)
         {
             (PlayFab as any)._internalSettings.productionServerUrl = `.${this.state.cloud}.playfabapi.com`
         }
->>>>>>> Add private cloud support
-        PlayFab.settings.titleId = this.state.titleId;
         
         this.props.history.push(routes.MainMenu(this.state.titleId));
     }

--- a/source/app/pages/index.tsx
+++ b/source/app/pages/index.tsx
@@ -81,6 +81,11 @@ class IndexPageBase extends React.Component<Props, IState> {
             e.preventDefault();
         }
 
+<<<<<<< HEAD
+=======
+    private saveTitleID = (): void => {
+        (PlayFab as any)._internalSettings.productionServerUrl = `.spi.playfabapi.com`
+>>>>>>> Works hardcoded cloud
         PlayFab.settings.titleId = this.state.titleId;
         
         this.props.history.push(routes.MainMenu(this.state.titleId));

--- a/source/app/pages/index.tsx
+++ b/source/app/pages/index.tsx
@@ -16,6 +16,7 @@ const TextFieldTitleId = styled(TextField)`
 
 interface IState {
     titleId: string;
+    cloud: string;
 }
 
 type Props = RouteComponentProps & IWithAppStateProps;
@@ -24,12 +25,17 @@ class IndexPageBase extends React.Component<Props, IState> {
     constructor(props: Props) {
         super(props);
 
+        const cloud = (props.match.params as any).cloud || "";
+
         this.state = {
-            titleId: null,
+            titleId: "",
+            cloud,
         }
     }
 
     public render(): React.ReactNode {
+        const shouldShowCloud = !is.null((this.props.match.params as any).cloud);
+
         return (
             <Page {...this.props} title="PlayFab Demo Game">
                 <Grid grid8x4>
@@ -41,6 +47,11 @@ class IndexPageBase extends React.Component<Props, IState> {
                         <DivField>
                             <TextFieldTitleId label="Title ID" onChange={this.onChangeTitleId} value={this.state.titleId} autoFocus />
                         </DivField>
+                        {shouldShowCloud && (
+                            <DivField>
+                                <TextField label="Cloud" onChange={this.onChangeCloud} value={this.state.cloud} />
+                            </DivField>
+                        )}
                         <DivConfirm>
                             <PrimaryButton text="Continue" onClick={this.continue} />
                         </DivConfirm>

--- a/source/app/pages/upload.tsx
+++ b/source/app/pages/upload.tsx
@@ -166,7 +166,7 @@ class UploadPageBase extends React.Component<Props, IState> {
 
         return (
             <React.Fragment>
-                <h2>Upload in progress to {(PlayFab as any)._internalSettings.GetServerUrl()}</h2>
+                <h2>Upload in progress</h2>
                 {!is.null(this.props.pageError) && (
                     <MessageBar messageBarType={MessageBarType.error}>{this.props.pageError}</MessageBar>
                 )}

--- a/source/app/pages/upload.tsx
+++ b/source/app/pages/upload.tsx
@@ -166,7 +166,7 @@ class UploadPageBase extends React.Component<Props, IState> {
 
         return (
             <React.Fragment>
-                <h2>Upload in progress</h2>
+                <h2>Upload in progress to {(PlayFab as any)._internalSettings.GetServerUrl()}</h2>
                 {!is.null(this.props.pageError) && (
                     <MessageBar messageBarType={MessageBarType.error}>{this.props.pageError}</MessageBar>
                 )}

--- a/source/app/routes.ts
+++ b/source/app/routes.ts
@@ -15,7 +15,7 @@ export const routeNames = {
 };
 
 export const routes = {
-    Index: () => routeNames.Index,
+    Index: (cloud: string) => utilities.formatRoute(routeNames.Index, cloud),
     MainMenu: (titleId: string) => utilities.formatRoute(routeNames.MainMenu, titleId),
     Login: (titleId: string) => utilities.formatRoute(routeNames.Login, titleId),
     Guide: (titleId: string) => utilities.formatRoute(routeNames.Guide, titleId),

--- a/source/app/routes.ts
+++ b/source/app/routes.ts
@@ -11,7 +11,6 @@ export const routeNames = {
     Download: "/:titleid/download",
     LevelCurve: "/:titleid/level-curve",
     Credits: "/:titleid/credits",
-    Webhook: "/:titleid/webhook",
 };
 
 export const routes = {
@@ -25,5 +24,4 @@ export const routes = {
     Download: (titleId: string) => utilities.formatRoute(routeNames.Download, titleId),
     LevelCurve: (titleId: string) => utilities.formatRoute(routeNames.LevelCurve, titleId),
     Credits: (titleId: string) => utilities.formatRoute(routeNames.Credits, titleId),
-    Webhook: (titleId: string) => utilities.formatRoute(routeNames.Webhook, titleId),
 };

--- a/source/app/routes.ts
+++ b/source/app/routes.ts
@@ -1,7 +1,7 @@
 import { utilities } from "./shared/utilities";
 
 export const routeNames = {
-    Index: "/",
+    Index: "/:cloud?",
     MainMenu: "/:titleid/menu",
     Login: "/:titleid/login",
     Guide: "/:titleid/guide",
@@ -11,6 +11,7 @@ export const routeNames = {
     Download: "/:titleid/download",
     LevelCurve: "/:titleid/level-curve",
     Credits: "/:titleid/credits",
+    Webhook: "/:titleid/webhook",
 };
 
 export const routes = {
@@ -24,4 +25,5 @@ export const routes = {
     Download: (titleId: string) => utilities.formatRoute(routeNames.Download, titleId),
     LevelCurve: (titleId: string) => utilities.formatRoute(routeNames.LevelCurve, titleId),
     Credits: (titleId: string) => utilities.formatRoute(routeNames.Credits, titleId),
+    Webhook: (titleId: string) => utilities.formatRoute(routeNames.Webhook, titleId),
 };

--- a/source/app/shared/utilities.ts
+++ b/source/app/shared/utilities.ts
@@ -25,22 +25,28 @@ function formatRoute(original: string, ...args: string[]): string {
 function createPlayFabLink(titleId: string, uri: string, isReact: boolean): string {
     const playFabMainProdUrl = ".playfabapi.com";
 
-    var urlRoot;
+    let urlRoot : string;
 
+    // TODO when cloud moves to URI, use that value instead of pulling from productionServerUrl
     if(((PlayFab as any)._internalSettings.productionServerUrl === playFabMainProdUrl))
     {
-        urlRoot = "https://developer.playfab.comm";
+        urlRoot = "https://developer.playfab.com";
     }
     else
     {
-        var prodUrl = ((PlayFab as any)._internalSettings.productionServerUrl as string);
-        var cloudEndIndex = prodUrl.indexOf(playFabMainProdUrl);
-        var cloud = (PlayFab as any)._internalSettings.productionServerUrl.substring(1, cloudEndIndex);
+        const prodUrl = ((PlayFab as any)._internalSettings.productionServerUrl as string);
+        const cloudEndIndex = prodUrl.indexOf(playFabMainProdUrl);
+        const cloud = (PlayFab as any)._internalSettings.productionServerUrl.substring(1, cloudEndIndex);
 
         urlRoot = `https://${cloud}.${cloud}.playfab.com`;
     }
 
     return `${urlRoot}/en-US/${isReact ? `r/t/` : ``}${titleId}/${uri}`;
+}
+
+
+function setPrivateCloud(cloud: string): void {
+    (PlayFab as any)._internalSettings.productionServerUrl = `.${cloud}.playfabapi.com`;
 }
 
 function htmlDecode(input: string): string {
@@ -67,6 +73,7 @@ export const utilities = {
     getRandomInteger,
     formatRoute,
     createPlayFabLink,
+    setPrivateCloud,
     htmlDecode,
     parseTitleNewsDate
 };

--- a/source/app/shared/utilities.ts
+++ b/source/app/shared/utilities.ts
@@ -11,7 +11,7 @@ function formatRoute(original: string, ...args: string[]): string {
         return "";
     }
 
-    const replaceRegEx = new RegExp("((?:\:)[a-z]+)");
+    const replaceRegEx = new RegExp("((?:\:)[a-z?]+)");
 
     let returnString = original;
 
@@ -23,7 +23,24 @@ function formatRoute(original: string, ...args: string[]): string {
 }
 
 function createPlayFabLink(titleId: string, uri: string, isReact: boolean): string {
-    return `https://developer.playfab.com/en-US/${isReact ? `r/t/` : ``}${titleId}/${uri}`;
+    const playFabMainProdUrl = ".playfabapi.com";
+
+    var urlRoot;
+
+    if(((PlayFab as any)._internalSettings.productionServerUrl === playFabMainProdUrl))
+    {
+        urlRoot = "https://developer.playfab.comm";
+    }
+    else
+    {
+        var prodUrl = ((PlayFab as any)._internalSettings.productionServerUrl as string);
+        var cloudEndIndex = prodUrl.indexOf(playFabMainProdUrl);
+        var cloud = (PlayFab as any)._internalSettings.productionServerUrl.substring(1, cloudEndIndex);
+
+        urlRoot = `https://${cloud}.${cloud}.playfab.com`;
+    }
+
+    return `${urlRoot}/en-US/${isReact ? `r/t/` : ``}${titleId}/${uri}`;
 }
 
 function htmlDecode(input: string): string {


### PR DESCRIPTION
Add support for private clouds.

At the index page, adds an optional parameter to the url. If specified adds an additional field to enter cloud name.

To try it out, go to https://playfabhack.azurewebsites.net/#/spi

Currently it is only stored from the index page so direct links to other pages will always default to main cloud. We can consider adding it to the URI on other pages to fix that issue.